### PR TITLE
Add URL Validation Infrastructure

### DIFF
--- a/lib/url_validator.rb
+++ b/lib/url_validator.rb
@@ -1,0 +1,119 @@
+require "uri"
+require "net/http"
+require "timeout"
+
+class URLValidator
+  # Timeout for HTTP requests in seconds
+  HTTP_TIMEOUT = 5
+
+  # Known fake/placeholder domains
+  FAKE_DOMAINS = %w[
+    example.com
+    example.org
+    example.net
+    test.com
+    localhost
+    127.0.0.1
+    0.0.0.0
+    placeholder.com
+    dummy.com
+    fake.com
+    mock.com
+    sample.com
+    testing.com
+  ].freeze
+
+  # Government domain suffixes
+  GOVERNMENT_SUFFIXES = %w[
+    .gov
+    .gov.uk
+    .gc.ca
+    .gov.au
+    .gouv.fr
+    .gob.es
+    .governo.it
+    .gov.br
+  ].freeze
+
+  def initialize
+    # Instance variables for caching if needed in the future
+  end
+
+  # Check if URL has valid format
+  def valid_url?(url)
+    return false if url.nil? || url.to_s.strip.empty?
+
+    begin
+      uri = URI.parse(url.to_s.strip)
+      # Must have a scheme (http/https) and host
+      uri.is_a?(URI::HTTP) && !uri.host.nil? && !uri.host.empty?
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+
+  # Check if URL is reachable via HTTP request
+  def reachable?(url)
+    return false unless valid_url?(url)
+
+    begin
+      uri = URI.parse(url.to_s.strip)
+      
+      Timeout.timeout(HTTP_TIMEOUT) do
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+          request = Net::HTTP::Head.new(uri.path.empty? ? "/" : uri.path)
+          response = http.request(request)
+          
+          # Consider 2xx and 3xx as reachable
+          response.code.to_i.between?(200, 399)
+        end
+      end
+    rescue StandardError
+      # Catch all network errors, timeouts, SSL errors, etc.
+      false
+    end
+  end
+
+  # Check if URL belongs to a government domain
+  def government_domain?(url)
+    return false unless valid_url?(url)
+
+    begin
+      uri = URI.parse(url.to_s.strip)
+      host = uri.host.downcase
+      
+      GOVERNMENT_SUFFIXES.any? { |suffix| host.end_with?(suffix) }
+    rescue StandardError
+      false
+    end
+  end
+
+  # Check if URL appears to be fake/placeholder
+  def fake_url?(url)
+    return true unless valid_url?(url)
+
+    begin
+      uri = URI.parse(url.to_s.strip)
+      host = uri.host.downcase
+      
+      # Check against known fake domains
+      FAKE_DOMAINS.include?(host) ||
+        # Check for localhost variations
+        host.start_with?("localhost") ||
+        # Check for IP addresses that are local/private
+        host.match?(/^192\.168\./) ||
+        host.match?(/^10\./) ||
+        host.match?(/^172\.(1[6-9]|2[0-9]|3[0-1])\./) ||
+        # Check for common test patterns
+        host.include?("test") ||
+        host.include?("example") ||
+        host.include?("placeholder") ||
+        host.include?("dummy") ||
+        host.include?("fake") ||
+        host.include?("mock") ||
+        host.include?("sample")
+    rescue StandardError
+      true # If we can't parse it, consider it fake
+    end
+  end
+end

--- a/spec/lib/url_validator_spec.rb
+++ b/spec/lib/url_validator_spec.rb
@@ -1,0 +1,216 @@
+require_relative "../../lib/url_validator"
+
+RSpec.describe URLValidator do
+  let(:validator) { URLValidator.new }
+
+  describe "#valid_url?" do
+    it "returns true for valid HTTP URLs" do
+      expect(validator.valid_url?("http://example.com")).to be true
+      expect(validator.valid_url?("http://www.google.com/path?query=value")).to be true
+    end
+
+    it "returns true for valid HTTPS URLs" do
+      expect(validator.valid_url?("https://example.com")).to be true
+      expect(validator.valid_url?("https://subdomain.example.com/path")).to be true
+    end
+
+    it "returns false for URLs without schemes" do
+      expect(validator.valid_url?("example.com")).to be false
+      expect(validator.valid_url?("www.google.com")).to be false
+    end
+
+    it "returns false for malformed URLs" do
+      expect(validator.valid_url?("http://")).to be false
+      expect(validator.valid_url?("https://")).to be false
+      expect(validator.valid_url?("not-a-url")).to be false
+      expect(validator.valid_url?("http:///path")).to be false
+    end
+
+    it "returns false for nil, empty, or whitespace-only URLs" do
+      expect(validator.valid_url?(nil)).to be false
+      expect(validator.valid_url?("")).to be false
+      expect(validator.valid_url?("   ")).to be false
+    end
+
+    it "handles URLs with different schemes appropriately" do
+      expect(validator.valid_url?("ftp://example.com")).to be false
+      expect(validator.valid_url?("mailto:test@example.com")).to be false
+      expect(validator.valid_url?("file:///path/to/file")).to be false
+    end
+
+    it "strips whitespace from URLs before validation" do
+      expect(validator.valid_url?("  https://example.com  ")).to be true
+    end
+  end
+
+  describe "#government_domain?" do
+    it "returns true for US government domains" do
+      expect(validator.government_domain?("https://whitehouse.gov")).to be true
+      expect(validator.government_domain?("http://nasa.gov")).to be true
+      expect(validator.government_domain?("https://subdomain.state.gov")).to be true
+    end
+
+    it "returns true for international government domains" do
+      expect(validator.government_domain?("https://canada.gc.ca")).to be true
+      expect(validator.government_domain?("http://parliament.gov.uk")).to be true
+      expect(validator.government_domain?("https://diplomatie.gouv.fr")).to be true
+      expect(validator.government_domain?("https://presidency.gov.au")).to be true
+    end
+
+    it "returns false for non-government domains" do
+      expect(validator.government_domain?("https://google.com")).to be false
+      expect(validator.government_domain?("http://github.com")).to be false
+      expect(validator.government_domain?("https://example.org")).to be false
+    end
+
+    it "returns false for invalid URLs" do
+      expect(validator.government_domain?("not-a-url")).to be false
+      expect(validator.government_domain?(nil)).to be false
+      expect(validator.government_domain?("")).to be false
+    end
+
+    it "is case insensitive" do
+      expect(validator.government_domain?("HTTPS://NASA.GOV")).to be true
+      expect(validator.government_domain?("https://CANADA.GC.CA")).to be true
+    end
+  end
+
+  describe "#fake_url?" do
+    it "returns true for common fake domains" do
+      expect(validator.fake_url?("http://example.com")).to be true
+      expect(validator.fake_url?("https://example.org")).to be true
+      expect(validator.fake_url?("http://test.com")).to be true
+      expect(validator.fake_url?("https://placeholder.com")).to be true
+    end
+
+    it "returns true for localhost and local IPs" do
+      expect(validator.fake_url?("http://localhost")).to be true
+      expect(validator.fake_url?("https://localhost:3000")).to be true
+      expect(validator.fake_url?("http://127.0.0.1")).to be true
+      expect(validator.fake_url?("http://0.0.0.0")).to be true
+    end
+
+    it "returns true for private IP addresses" do
+      expect(validator.fake_url?("http://192.168.1.1")).to be true
+      expect(validator.fake_url?("https://10.0.0.1")).to be true
+      expect(validator.fake_url?("http://172.16.0.1")).to be true
+      expect(validator.fake_url?("https://172.25.255.254")).to be true
+    end
+
+    it "returns true for domains with test-related keywords" do
+      expect(validator.fake_url?("http://testing.example.com")).to be true
+      expect(validator.fake_url?("https://mydummysite.com")).to be true
+      expect(validator.fake_url?("http://mockapi.com")).to be true
+      expect(validator.fake_url?("https://sampledata.org")).to be true
+    end
+
+    it "returns false for legitimate domains" do
+      expect(validator.fake_url?("https://google.com")).to be false
+      expect(validator.fake_url?("http://github.com")).to be false
+      expect(validator.fake_url?("https://stackoverflow.com")).to be false
+      expect(validator.fake_url?("http://news.ycombinator.com")).to be false
+    end
+
+    it "returns true for malformed URLs" do
+      expect(validator.fake_url?("not-a-url")).to be true
+      expect(validator.fake_url?("http://")).to be true
+      expect(validator.fake_url?("malformed")).to be true
+    end
+
+    it "returns true for nil or empty URLs" do
+      expect(validator.fake_url?(nil)).to be true
+      expect(validator.fake_url?("")).to be true
+      expect(validator.fake_url?("   ")).to be true
+    end
+
+    it "is case insensitive for domain matching" do
+      expect(validator.fake_url?("HTTP://EXAMPLE.COM")).to be true
+      expect(validator.fake_url?("https://TEST.ORG")).to be true
+    end
+  end
+
+  describe "#reachable?" do
+    # Note: These tests involve actual network calls and may be unreliable
+    # In a real environment, you might want to mock these or use VCR
+    
+    context "with valid URLs" do
+      it "returns false for invalid URLs first" do
+        expect(validator.reachable?("not-a-url")).to be false
+        expect(validator.reachable?(nil)).to be false
+      end
+
+      # These tests may be flaky due to network conditions
+      # Consider mocking in production tests
+      it "handles network timeouts gracefully" do
+        # This should timeout quickly due to non-routable IP
+        expect(validator.reachable?("http://10.255.255.1")).to be false
+      end
+
+      it "handles SSL errors gracefully" do
+        # This might cause SSL errors on some systems
+        # The method should handle them gracefully
+        result = validator.reachable?("https://self-signed.badssl.com")
+        expect(result).to be_in([true, false]) # Either works or fails gracefully
+      end
+    end
+
+    context "with localhost URLs" do
+      it "returns false for unreachable localhost ports" do
+        # Assuming port 99999 is not in use
+        expect(validator.reachable?("http://localhost:99999")).to be false
+      end
+    end
+
+    # Performance test to ensure < 5 second requirement
+    it "completes within the timeout limit" do
+      start_time = Time.now
+      validator.reachable?("http://10.255.255.1") # Non-routable IP
+      end_time = Time.now
+      
+      expect(end_time - start_time).to be < URLValidator::HTTP_TIMEOUT + 1
+    end
+  end
+
+  describe "integration scenarios" do
+    it "correctly categorizes a mix of URL types" do
+      urls = [
+        "https://whitehouse.gov",           # valid, government, not fake, potentially reachable
+        "http://example.com",              # valid, not government, fake
+        "https://google.com",              # valid, not government, not fake, likely reachable
+        "not-a-url",                       # invalid, not government, fake
+        "http://localhost:3000",           # valid, not government, fake
+        "",                                # invalid, not government, fake
+        "https://canada.gc.ca"             # valid, government, not fake, potentially reachable
+      ]
+
+      results = urls.map do |url|
+        {
+          url: url,
+          valid: validator.valid_url?(url),
+          government: validator.government_domain?(url),
+          fake: validator.fake_url?(url)
+        }
+      end
+
+      # Test expected patterns
+      expect(results[0][:valid]).to be true    # whitehouse.gov
+      expect(results[0][:government]).to be true
+      expect(results[0][:fake]).to be false
+
+      expect(results[1][:valid]).to be true    # example.com
+      expect(results[1][:government]).to be false
+      expect(results[1][:fake]).to be true
+
+      expect(results[2][:valid]).to be true    # google.com
+      expect(results[2][:government]).to be false
+      expect(results[2][:fake]).to be false
+
+      expect(results[3][:valid]).to be false   # not-a-url
+      expect(results[3][:fake]).to be true
+
+      expect(results[4][:valid]).to be true    # localhost:3000
+      expect(results[4][:government]).to be false
+      expect(results[4][:fake]).to be true
+    end
+  end
+end


### PR DESCRIPTION
Add foundational URL validation system to detect and filter fake/invalid URLs from pitch opportunities.

## Changes
- Implement URLValidator class with methods for validation, reachability, government domain detection, and fake URL detection
- Add comprehensive unit tests with edge cases and performance requirements
- Handles malformed URLs, timeouts, and network errors gracefully
- Meets performance requirement of < 5 seconds per URL validation

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)